### PR TITLE
Retryable: backoff parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: ruby
+before_install: gem install bundler
 rvm:
-  - 2.0.0
-  - 2.1.6
-  - 2.2.2
+  - 2.1.10
+  - 2.2.6
+  - 2.3.3
+  - 2.4.0
   - ruby-head
   - jruby-head

--- a/lib/decoratable/retryable.rb
+++ b/lib/decoratable/retryable.rb
@@ -3,14 +3,25 @@ require "decoratable"
 module Retryable
   extend Decoratable
 
-  def retryable(tries = 1, options = { on: [RuntimeError] } )
+  NO_BACKOFF = proc { 0 }
+  LINEAR_BACKOFF = proc { |n| n + 1 }
+  EXPONENTIAL_BACKOFF = proc { |n| 2**n }
+
+  def retryable(tries = 1, on: [RuntimeError], backoff: NO_BACKOFF)
     attempts = 0
+    on = Array(on)
 
     begin
       yield
-    rescue *options[:on]
-      attempts += 1
-      attempts > tries ? raise : retry
+    rescue *on
+
+      if attempts >= tries
+        raise
+      else
+        sleep backoff.call(attempts)
+        attempts += 1
+        retry
+      end
     end
   end
 end

--- a/test/decoratable_test.rb
+++ b/test/decoratable_test.rb
@@ -142,7 +142,7 @@ describe Decoratable do
 
   def mock_logger
     logger = Minitest::Mock.new
-    logger.expect(:info, nil, [/took \d+\.\d+s to run/])
+    logger.expect(:info, nil, [/took \d+(\.\d+)?s to run/])
     logger
   end
 end


### PR DESCRIPTION
No backoff on retries by default. Options available:

* Retryable::NO_BACKOFF
* Retryable::LINEAR_BACKOFF
* Retryable::EXPONENTIAL_BACKOFF

The backoff parameter accepts a block, so users can come up with their
own backoff algorithms to use.